### PR TITLE
Fix demo data file path in hr_hospital module

### DIFF
--- a/hr_hospital/__manifest__.py
+++ b/hr_hospital/__manifest__.py
@@ -16,7 +16,7 @@
         'data/disease_data.xml',
     ],
     'demo': [
-        'data/demo_data.xml',
+        'demo/demo_data.xml',
     ],
     'installable': True,
     'application': True,


### PR DESCRIPTION
Corrected the demo data file path in the __manifest__.py file of the hr_hospital module. This change ensures that the demo data is properly loaded when the module is installed.