### PR TITLE
Add .gitignore to exclude hr_hospital.zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/hr_hospital.zip


### PR DESCRIPTION
This commit introduces a .gitignore file to manage repository hygiene. The file is configured to exclude hr_hospital.zip, ensuring it doesn't clutter the repository.